### PR TITLE
fix: correct auto complete integration test

### DIFF
--- a/__tests__/UsAutocompletionsApi.spec.ts
+++ b/__tests__/UsAutocompletionsApi.spec.ts
@@ -12,7 +12,7 @@ describe("USAutocompletionsApi", () => {
     address_prefix: "1313",
     city: "WESTFIELD",
     state: "NJ",
-    zip_code: "07000",
+    zip_code: "07090",
     geo_ip_sort: false,
   };
 


### PR DESCRIPTION
## Description
Correct a value used in auto complete integration testing that results in no suggestions;

## Verify
 - [x] Code runs without errors
 - [x] Tests pass with 100% coverage