### PR TITLE
Chore: Increase unit test coverage for Reverse Geocode Lookups to 100%

### DIFF
--- a/__tests__/ReverseGeocodeLookupsApi.unit.ts
+++ b/__tests__/ReverseGeocodeLookupsApi.unit.ts
@@ -60,12 +60,12 @@ describe("ReverseGeocodeLookupsApi", () => {
       }));
 
       const geocodeResult = await new ReverseGeocodeLookupsApi(config).lookup(
-        mockLocation, 2
+        mockLocation,
+        2
       );
       expect(geocodeResult).toBeDefined();
       expect(geocodeResult.id).toEqual("us_reverse_geocode_fakeId");
     });
-
 
     it("includes custom headers while it looks up a geocode", async () => {
       axiosRequest.mockImplementationOnce(async () => ({


### PR DESCRIPTION
## Description

Increase unit test coverage for Reverse Geocode Lookups

## Story

[JIRA-715](https://lobsters.atlassian.net/browse/DXP-715)

## Related PR's



## Verify

- [ x] Code runs without errors
- [x ] Tests pass with 100% coverage
<img width="1789" alt="Screen Shot 2022-01-25 at 10 07 53 PM" src="https://user-images.githubusercontent.com/70728971/151097498-83cbe6ff-22ee-4872-8f8a-3865812d4e7c.png">

