### PR TITLE
chore: increase unit test coverage to 100% for us and int verifications

### DIFF
--- a/__tests__/IntlVerifications.spec.ts
+++ b/__tests__/IntlVerifications.spec.ts
@@ -48,15 +48,17 @@ describe("IntlVerificationsApi", () => {
     });
 
     it("verifies a single international address", async () => {
-      const intlvApi = new IntlVerificationsApi(config);
-      const response = await intlvApi.verifySingle(multiLine);
-      expect(response?.status).toBeDefined();
+      const response = await new IntlVerificationsApi(config).verifySingle(
+        multiLine
+      );
+      expect(response.status).toBeDefined();
     });
 
     it("verifies a single-line international address", async () => {
-      const intlvApi = new IntlVerificationsApi(config);
-      const response = await intlvApi.verifySingle(singleLine);
-      expect(response?.status).toBeDefined();
+      const response = await new IntlVerificationsApi(config).verifySingle(
+        singleLine
+      );
+      expect(response.status).toBeDefined();
     });
   });
 
@@ -68,10 +70,11 @@ describe("IntlVerificationsApi", () => {
     });
 
     it("verifies a list of international addresses", async () => {
-      const intlvApi = new IntlVerificationsApi(config);
-      const response = await intlvApi.verifyBulk(addressList);
+      const response = await new IntlVerificationsApi(config).verifyBulk(
+        addressList
+      );
       expect(response).toBeDefined();
-      expect(response?.addresses?.length).toEqual(2);
+      expect(response.addresses?.length).toEqual(2);
     });
   });
 });

--- a/__tests__/IntlVerifications.unit.ts
+++ b/__tests__/IntlVerifications.unit.ts
@@ -1,0 +1,271 @@
+import { Configuration } from "../configuration";
+
+import {
+  IntlVerificationWritable,
+  CountryExtended,
+  IntlVerificationsPayload,
+  IntlVerificationStatusEnum,
+} from "../models";
+import { AddressesApi, IntlVerificationsApi } from "../api";
+import { fail } from "./testUtilities";
+
+// Axios Mock
+import axios from "axios";
+const axiosRequest: jest.Mock = axios.request as jest.Mock;
+jest.mock("axios", () => ({
+  request: jest.fn(),
+}));
+
+describe("IntlVerificationsApi", () => {
+  const config: Configuration = new Configuration({
+    username: "Totally Fake Key",
+  });
+  const configWithBaseOptions = new Configuration({
+    username: "Totally Fake Key",
+    baseOptions: {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  });
+
+  it("can be instantiated", () => {
+    const intlvApi = new IntlVerificationsApi(config);
+    expect(intlvApi).toBeDefined();
+    expect(typeof intlvApi).toEqual("object");
+    expect(intlvApi).toBeInstanceOf(IntlVerificationsApi);
+  });
+
+  it("can be instantiated with base options", () => {
+    const intlvApi = new IntlVerificationsApi(configWithBaseOptions);
+    expect(intlvApi).toBeDefined();
+    expect(typeof intlvApi).toEqual("object");
+    expect(intlvApi).toBeInstanceOf(IntlVerificationsApi);
+  });
+
+  describe("verifySingle", () => {
+    const verification: IntlVerificationWritable = {
+      primary_line: "370 WATER ST",
+      postal_code: "C1N 1C4",
+      country: CountryExtended.Ca,
+    };
+
+    it("exists", () => {
+      const intlvApi = new IntlVerificationsApi(config);
+      expect(intlvApi.verifySingle).toBeDefined();
+      expect(typeof intlvApi.verifySingle).toEqual("function");
+    });
+
+    it("handles errors returned by the api", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: { error: { message: "error reported by API" } } },
+        };
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifySingle(verification);
+      } catch (err: any) {
+        expect(err.message).toEqual("error reported by API");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: {},
+        };
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifySingle(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data.error", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: {} },
+        };
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifySingle(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors in making the request", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw new Error("Unknown Error");
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifySingle(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("Unknown Error");
+      }
+    });
+
+    it("verifies a single international address", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { status: IntlVerificationStatusEnum.Lf1 },
+      }));
+
+      const response = await new IntlVerificationsApi(config).verifySingle(
+        verification
+      );
+      expect(response.status).toBeDefined();
+      expect(response.status).toEqual(IntlVerificationStatusEnum.Lf1);
+    });
+
+    it("includes custom headers while it verifies a single international address", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { status: IntlVerificationStatusEnum.Lf1 },
+      }));
+
+      const response = await new IntlVerificationsApi(
+        configWithBaseOptions
+      ).verifySingle(verification);
+      expect(response.status).toBeDefined();
+      expect(response.status).toEqual(IntlVerificationStatusEnum.Lf1);
+    });
+
+    it("verifies a single international address with xLang", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { status: IntlVerificationStatusEnum.Lf1 },
+      }));
+
+      const response = await new IntlVerificationsApi(config).verifySingle(
+        verification,
+        "native"
+      );
+      expect(response.status).toBeDefined();
+      expect(response.status).toEqual(IntlVerificationStatusEnum.Lf1);
+    });
+  });
+
+  describe("verifyBulk", () => {
+    const verification: IntlVerificationsPayload = {
+      addresses: [
+        {
+          primary_line: "370 WATER ST",
+          postal_code: "C1N 1C4",
+          country: CountryExtended.Ca,
+        },
+        {
+          primary_line: "012 PLACEHOLDER ST",
+          postal_code: "F0O 8A2",
+          country: CountryExtended.Ca,
+        },
+      ],
+    };
+
+    it("exists", () => {
+      const intlvApi = new IntlVerificationsApi(config);
+      expect(intlvApi.verifyBulk).toBeDefined();
+      expect(typeof intlvApi.verifyBulk).toEqual("function");
+    });
+
+    it("handles errors returned by the api", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: { error: { message: "error reported by API" } } },
+        };
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifyBulk(verification);
+      } catch (err: any) {
+        expect(err.message).toEqual("error reported by API");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: {},
+        };
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifyBulk(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data.error", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: {} },
+        };
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifyBulk(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors in making the request", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw new Error("Unknown Error");
+      });
+
+      try {
+        await new IntlVerificationsApi(config).verifyBulk(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("Unknown Error");
+      }
+    });
+
+    it("verifies a list of international addresses", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: {
+          addresses: [
+            { status: IntlVerificationStatusEnum.Lf1 },
+            { status: IntlVerificationStatusEnum.Lf1 },
+          ],
+        },
+      }));
+      const response = await new IntlVerificationsApi(config).verifyBulk(
+        verification
+      );
+      expect(response).toBeDefined();
+      expect(response.addresses?.length).toEqual(2);
+    });
+
+    it("includes custom headers while it verifies a list of international addressess", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: {
+          addresses: [
+            { status: IntlVerificationStatusEnum.Lf1 },
+            { status: IntlVerificationStatusEnum.Lf1 },
+          ],
+        },
+      }));
+
+      const response = await new IntlVerificationsApi(
+        configWithBaseOptions
+      ).verifyBulk(verification);
+      expect(response.addresses?.length).toEqual(2);
+    });
+  });
+});

--- a/__tests__/UsVerifications.unit.ts
+++ b/__tests__/UsVerifications.unit.ts
@@ -1,0 +1,291 @@
+import { Configuration } from "../configuration";
+
+import {
+  UsVerificationsWritable,
+  MultipleComponentsList,
+  CountryExtended,
+  UsVerificationDeliverabilityEnum,
+} from "../models";
+import { USVerificationsApi } from "../api";
+import { fail } from "./testUtilities";
+
+// Axios Mock
+import axios from "axios";
+const axiosRequest: jest.Mock = axios.request as jest.Mock;
+jest.mock("axios", () => ({
+  request: jest.fn(),
+}));
+
+describe("USVerificationsApi", () => {
+  const config: Configuration = new Configuration({
+    username: "Totally Fake Key",
+  });
+  const configWithBaseOptions = new Configuration({
+    username: "Totally Fake Key",
+    baseOptions: {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  });
+
+  it("can be instantiated", () => {
+    const verificationApi = new USVerificationsApi(config);
+    expect(verificationApi).toBeDefined();
+    expect(typeof verificationApi).toEqual("object");
+    expect(verificationApi).toBeInstanceOf(USVerificationsApi);
+  });
+
+  it("can be instantiated with base options", () => {
+    const verificationApi = new USVerificationsApi(configWithBaseOptions);
+    expect(verificationApi).toBeDefined();
+    expect(typeof verificationApi).toEqual("object");
+    expect(verificationApi).toBeInstanceOf(USVerificationsApi);
+  });
+
+  describe("verifySingle", () => {
+    const verification: UsVerificationsWritable = {
+      primary_line: "370 WATER ST",
+      zip_code: "07090",
+    };
+
+    it("exists", () => {
+      const verificationApi = new USVerificationsApi(config);
+      expect(verificationApi.verifySingle).toBeDefined();
+      expect(typeof verificationApi.verifySingle).toEqual("function");
+    });
+
+    it("handles errors returned by the api", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: { error: { message: "error reported by API" } } },
+        };
+      });
+
+      try {
+        await new USVerificationsApi(config).verifySingle(verification);
+      } catch (err: any) {
+        expect(err.message).toEqual("error reported by API");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: {},
+        };
+      });
+
+      try {
+        await new USVerificationsApi(config).verifySingle(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data.error", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: {} },
+        };
+      });
+
+      try {
+        await new USVerificationsApi(config).verifySingle(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors in making the request", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw new Error("Unknown Error");
+      });
+
+      try {
+        await new USVerificationsApi(config).verifySingle(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("Unknown Error");
+      }
+    });
+
+    it("verifies a single international address", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+      }));
+
+      const response = await new USVerificationsApi(config).verifySingle(
+        verification
+      );
+      expect(response).toBeDefined();
+      expect(response.deliverability).toEqual(
+        UsVerificationDeliverabilityEnum.Deliverable
+      );
+    });
+
+    it("includes custom headers while it verifies a single international address", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+      }));
+
+      const response = await new USVerificationsApi(
+        configWithBaseOptions
+      ).verifySingle(verification);
+      expect(response).toBeDefined();
+      expect(response.deliverability).toEqual(
+        UsVerificationDeliverabilityEnum.Deliverable
+      );
+    });
+
+    it("verifies a single international address with a provided case", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+      }));
+
+      const response = await new USVerificationsApi(config).verifySingle(
+        verification,
+        "upper"
+      );
+      expect(response).toBeDefined();
+      expect(response.deliverability).toEqual(
+        UsVerificationDeliverabilityEnum.Deliverable
+      );
+    });
+  });
+
+  describe("verifyBulk", () => {
+    const verification: MultipleComponentsList = {
+      addresses: [
+        {
+          primary_line: "370 WATER ST",
+          zip_code: CountryExtended.Ca,
+        },
+        {
+          primary_line: "012 PLACEHOLDER ST",
+          zip_code: "F0O 8A2",
+        },
+      ],
+    };
+
+    it("exists", () => {
+      const verificationApi = new USVerificationsApi(config);
+      expect(verificationApi.verifyBulk).toBeDefined();
+      expect(typeof verificationApi.verifyBulk).toEqual("function");
+    });
+
+    it("handles errors returned by the api", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: { error: { message: "error reported by API" } } },
+        };
+      });
+
+      try {
+        await new USVerificationsApi(config).verifyBulk(verification);
+      } catch (err: any) {
+        expect(err.message).toEqual("error reported by API");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: {},
+        };
+      });
+
+      try {
+        await new USVerificationsApi(config).verifyBulk(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data.error", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: {} },
+        };
+      });
+
+      try {
+        await new USVerificationsApi(config).verifyBulk(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors in making the request", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw new Error("Unknown Error");
+      });
+
+      try {
+        await new USVerificationsApi(config).verifyBulk(verification);
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("Unknown Error");
+      }
+    });
+
+    it("verifies a list of international addresses", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: {
+          addresses: [
+            { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+            { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+          ],
+        },
+      }));
+      const response = await new USVerificationsApi(config).verifyBulk(
+        verification
+      );
+      expect(response).toBeDefined();
+      expect(response.addresses?.length).toEqual(2);
+    });
+
+    it("includes custom headers while it verifies a list of international addresses", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: {
+          addresses: [
+            { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+            { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+          ],
+        },
+      }));
+
+      const response = await new USVerificationsApi(
+        configWithBaseOptions
+      ).verifyBulk(verification);
+      expect(response.addresses?.length).toEqual(2);
+    });
+
+    it("verifies a list of international addresses with a provided case", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: {
+          addresses: [
+            { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+            { deliverability: UsVerificationDeliverabilityEnum.Deliverable },
+          ],
+        },
+      }));
+      const response = await new USVerificationsApi(config).verifyBulk(
+        verification,
+        "proper"
+      );
+      expect(response).toBeDefined();
+      expect(response.addresses?.length).toEqual(2);
+    });
+  });
+});

--- a/__tests__/UsVerificationsApi.spec.ts
+++ b/__tests__/UsVerificationsApi.spec.ts
@@ -47,13 +47,13 @@ describe("UsVerificationApi", () => {
     it("verifies a single multi-line US address", async () => {
       const usvApi = new USVerificationsApi(config);
       const response = await usvApi.verifySingle(singleAddress);
-      expect(response?.deliverability).toBeDefined();
+      expect(response.deliverability).toBeDefined();
     });
 
     it("verifies a single one-line US address", async () => {
       const usvApi = new USVerificationsApi(config);
       const response = await usvApi.verifySingle(singleLine);
-      expect(response?.deliverability).toBeDefined();
+      expect(response.deliverability).toBeDefined();
     });
   });
 
@@ -68,7 +68,7 @@ describe("UsVerificationApi", () => {
       const usvApi = new USVerificationsApi(config);
       const response = await usvApi.verifyBulk(addressList);
       expect(response).toBeDefined();
-      expect(response?.addresses?.length).toEqual(2);
+      expect(response.addresses?.length).toEqual(2);
     });
   });
 });

--- a/__tests__/ZipLookupApi.unit.ts
+++ b/__tests__/ZipLookupApi.unit.ts
@@ -1,0 +1,130 @@
+import { Configuration } from "../configuration";
+
+import { Zip } from "../models";
+import { ZipLookupsApi } from "../api";
+import { fail } from "./testUtilities";
+
+// Axios Mock
+import axios from "axios";
+const axiosRequest: jest.Mock = axios.request as jest.Mock;
+jest.mock("axios", () => ({
+  request: jest.fn(),
+}));
+
+describe("ZipLookupsApi", () => {
+  const config: Configuration = new Configuration({
+    username: "Totally Fake Key",
+  });
+  const configWithBaseOptions = new Configuration({
+    username: "Totally Fake Key",
+    baseOptions: {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  });
+
+  it("can be instantiated", () => {
+    const zipLookupsApi = new ZipLookupsApi(config);
+    expect(zipLookupsApi).toBeDefined();
+    expect(typeof zipLookupsApi).toEqual("object");
+    expect(zipLookupsApi).toBeInstanceOf(ZipLookupsApi);
+  });
+
+  it("can be instantiated with base options", () => {
+    const zipLookupsApi = new ZipLookupsApi(configWithBaseOptions);
+    expect(zipLookupsApi).toBeDefined();
+    expect(typeof zipLookupsApi).toEqual("object");
+    expect(zipLookupsApi).toBeInstanceOf(ZipLookupsApi);
+  });
+
+  describe("lookup", () => {
+    it("exists", () => {
+      const zipLookupsApi = new ZipLookupsApi(config);
+      expect(zipLookupsApi.lookup).toBeDefined();
+      expect(typeof zipLookupsApi.lookup).toEqual("function");
+    });
+
+    it("handles errors returned by the api", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: { error: { message: "error reported by API" } } },
+        };
+      });
+
+      try {
+        await new ZipLookupsApi(config).lookup("07090");
+      } catch (err: any) {
+        expect(err.message).toEqual("error reported by API");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: {},
+        };
+      });
+
+      try {
+        await new ZipLookupsApi(config).lookup("07090");
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors returned by the api with missing response.data.error", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw {
+          message: "error",
+          response: { data: {} },
+        };
+      });
+
+      try {
+        await new ZipLookupsApi(config).lookup("07090");
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("error");
+      }
+    });
+
+    it("handles errors in making the request", async () => {
+      axiosRequest.mockImplementationOnce(async () => {
+        throw new Error("Unknown Error");
+      });
+
+      try {
+        await new ZipLookupsApi(config).lookup("07090");
+        fail("Should throw");
+      } catch (err: any) {
+        expect(err.message).toEqual("Unknown Error");
+      }
+    });
+
+    it("verifies a single international address", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { id: "us_zip_fakeId" },
+      }));
+
+      const response = await new ZipLookupsApi(config).lookup("07090");
+      expect(response).toBeDefined();
+      expect(response.id).toEqual("us_zip_fakeId");
+    });
+
+    it("includes custom headers while it verifies a single international address", async () => {
+      axiosRequest.mockImplementationOnce(async () => ({
+        data: { id: "us_zip_fakeId" },
+      }));
+
+      const response = await new ZipLookupsApi(configWithBaseOptions).lookup(
+        "07090"
+      );
+      expect(response).toBeDefined();
+      expect(response.id).toEqual("us_zip_fakeId");
+    });
+  });
+});


### PR DESCRIPTION
## Description
increase unit test coverage to 100% for us and int verifications
increase unit test coverage to 100% for zipLookup

## Story
[JIRA-718](https://lobsters.atlassian.net/browse/DXP-718)


## Verify
- [x] Code runs without errors
- [x] Tests pass with 100% coverage
