### PR TITLE
Dxp 994 consistent api key names 

### DIFF
--- a/.github/workflows/forked_run_tests.yml
+++ b/.github/workflows/forked_run_tests.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Run Integration Tests
         env:
-          LOB_API_KEY: ${{ secrets.LOB_API_KEY }}
-          LOB_LIVE_API_KEY: ${{ secrets.LOB_LIVE_API_KEY }}
+          LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
+          LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}
         run: npm run test:integration
 
       - name: Coveralls

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -18,7 +18,7 @@ jobs:
       - name: run contract tests
         uses: ./actions/monitoring/
         env:
-          LOB_API_KEY: ${{ secrets.LOB_API_KEY }}
+          LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
           LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Run Integration Tests
         env:
-          LOB_API_KEY: ${{ secrets.LOB_API_KEY }}
-          LOB_LIVE_API_KEY: ${{ secrets.LOB_LIVE_API_KEY }}
+          LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
+          LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}
         run: npm run test:integration
 
       - name: Coveralls

--- a/Migration.md
+++ b/Migration.md
@@ -46,7 +46,7 @@ _Note:_ To use the new TypeScript SDK in a JavaScript app the code looks like th
 const { Configuration } = require("@lob/lob-typescript-sdk");
 
 const config = new Configuration({
-  username: process.env.LOB_API_KEY,
+  username: process.env.LOB_API_TEST_KEY,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Integration tests run against a live deployment of the Lob API and require multi
 To run integration tests:
 
 ```bash
-$ LOB_API_KEY=<<API KEY 1>> LOB_LIVE_API_KEY=<< API KEY 2>> npm run test:integration
+$ LOB_API_LIVE_KEY=<<API KEY 1>> LOB_API_LIVE_KEY=<< API KEY 2>> npm run test:integration
 ```
 
 #### A cleaner alternative if you are going to run integration tests frequently
@@ -91,7 +91,7 @@ $ LOB_API_KEY=<<API KEY 1>> LOB_LIVE_API_KEY=<< API KEY 2>> npm run test:integra
 Run this the first time:
 
 ```bash
-$ echo "LOB_API_KEY=<<API KEY 1>>\nLOB_LIVE_API_KEY=<< API KEY 2>>" > LOCAL.env
+$ echo "LOB_API_LIVE_KEY=<<API KEY 1>>\nLOB_API_LIVE_KEY=<< API KEY 2>>" > LOCAL.env
 ```
 
 Then, to run the integration tests:

--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -176,7 +176,7 @@ describe("AddressApi", () => {
   // Module level container
   jest.setTimeout(1000 * 60); // Extends the allowed time for the test
   const config: Configuration = new Configuration({
-    username: process.env.LOB_API_KEY,
+    username: process.env.LOB_API_TEST_KEY,
   }); // Static data required for the remote call
 
   const addressCreate: AddressEditable = {

--- a/__tests__/js/AddressApi.spec.js
+++ b/__tests__/js/AddressApi.spec.js
@@ -2,7 +2,7 @@ const { AddressesApi } = require("../../api");
 
 describe("AddressApi Javascript Consumer", () => {
   const config = {
-    username: process.env.LOB_API_TEST_KEY,
+    username: process.env.LOB_API_TEST_KEY || process.env.LOB_API_LIVE_KEY,
   };
 
   let addressApi;

--- a/__tests__/js/AddressApi.spec.js
+++ b/__tests__/js/AddressApi.spec.js
@@ -2,7 +2,7 @@ const { AddressesApi } = require("../../api");
 
 describe("AddressApi Javascript Consumer", () => {
   const config = {
-    username: process.env.LOB_API_KEY,
+    username: process.env.LOB_API_TEST_KEY,
   };
 
   let addressApi;

--- a/__tests__/testFixtures.ts
+++ b/__tests__/testFixtures.ts
@@ -25,11 +25,11 @@ export const METADATA_OBJECT: { [key: string]: string } = {
 export const METADATA_QUERY_STRING: string =
   "metadata=%7B%22fakeMetadata%22%3A%22fakemetadata%22%7D";
 export const CONFIG_FOR_INTEGRATION: Configuration = new Configuration({
-  username: process.env.LOB_API_KEY,
+  username: process.env.LOB_API_TEST_KEY,
 });
 export const CONFIG_FOR_INTEGRATION_WITH_LIVE: Configuration =
   new Configuration({
-    username: process.env.LOB_LIVE_API_KEY,
+    username: process.env.LOB_API_LIVE_KEY,
   });
 export const CONFIG_FOR_UNIT: Configuration = new Configuration({
   username: "Totally Fake Key",


### PR DESCRIPTION
## Description

- Changed the api key to be lob_api_test_key
- Changed the live api key to be lob_api_live_key

## Story

[JIRA-994](https://lobsters.atlassian.net/browse/DXP-994)

## Related PR's

[Generator](https://github.com/lob/sdks_openapi_gen/pull/XX)

## Verify

- [ ] Code runs without errors
- [ ] Tests pass with >=85% coverage
