### PR TITLE
fix: add types to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "exports": {
     "node": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs.js"
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts"
     },
     "default": "./dist/index.mjs"
   },


### PR DESCRIPTION
## Description

With `"moduleResolution": "node16"` in `tsconfig.json` I'm getting the error `Could not find a declaration file for module '@lob/lob-typescript-sdk' '<project_root>/node_modules/@lob/lob-typescript-sdk/dist/index.mjs' implicitly has an 'any' type`

I believe this fixes that

## Story

## Related PR's

## Verify

- [ ] Code runs without errors
- [ ] Tests pass with >=85% coverage
