### PR TITLE
fix(us_verifications): Fix us_verifications valid address return type.

### DIFF
--- a/models/us-verification.ts
+++ b/models/us-verification.ts
@@ -126,7 +126,7 @@ export class UsVerification {
    * @type {boolean}
    * @memberof UsVerification
    */
-  "valid_address"?: UsVerificationValidAddressEnum;
+  "valid_address"?: boolean
 
   /**
    *
@@ -177,14 +177,6 @@ export enum UsVerificationDeliverabilityEnum {
   DeliverableIncorrectUnit = "deliverable_incorrect_unit",
   DeliverableMissingUnit = "deliverable_missing_unit",
   Undeliverable = "undeliverable",
-}
-/**
- * @export
- * @enum {string}
- */
-export enum UsVerificationValidAddressEnum {
-  True = "true",
-  False = "false",
 }
 /**
  * @export


### PR DESCRIPTION
## Description

Addressing this [issue](https://github.com/lob/lob-typescript-sdk/issues/269)

Typescript doesn't allow you to assign a boolean to a enum ie 
```enum value = { test = true }```

But if the value is boolean why do we need an enum?



## Story

[JIRA-XXX](https://lobsters.atlassian.net/browse/DXP-XXX)

## Related PR's

[Generator](https://github.com/lob/sdks_openapi_gen/pull/XX)

## Verify

- [ ] Code runs without errors
- [ ] Tests pass with >=85% coverage
