### PR TITLE
PLAT-2193: update deprecated GitHub Actions 

### DIFF
--- a/.github/workflows/forked_run_tests.yml
+++ b/.github/workflows/forked_run_tests.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         node: ["20", "21"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: "main"
 

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -14,10 +14,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # use node setup library (more info here https://github.com/actions/setup-node)
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -25,7 +25,7 @@ jobs:
         run: npm install
 
       # publishes to NPM using third party tool (more info here https://github.com/JS-DevTools/npm-publish)
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm install
       - run: npm test
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           tag: latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         node: ["20", "21"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/verify_automation_health.yml
+++ b/.github/workflows/verify_automation_health.yml
@@ -13,7 +13,7 @@ jobs:
   verify_authors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Description

* `actions/checkout@v2`, `actions/setup-node@v2`, `JS-DevTools/npm-publish@v1`,  `actions/checkout@v3` and `actions/setup-node@v3` run Node 12 or 16 and are deprecated, we need them to run Node 20:

See:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
and
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

---

![image](https://github.com/lob/lob-typescript-sdk/assets/117756379/15ab71a3-9599-432f-8b4e-f3ac1e2f51a7)

## Story

[PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

## Related PR's

[Generator](https://github.com/lob/sdks_openapi_gen/pull/XX)

## Verify

- [ ] Code runs without errors
- [ ] Tests pass with >=85% coverage


[PLAT-2193]: https://lobsters.atlassian.net/browse/PLAT-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ