### PR TITLE
Fix default field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
       "require": "./dist/index.cjs.js",
       "types": "./dist/index.d.ts"
     },
-    "default": "./dist/index.mjs"
+    "default": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
   "dependencies": {
     "axios": "^1.9.0",


### PR DESCRIPTION
Updated the 'default' field to include types which avoids import issues such as the below error:

Could not find a declaration file for module '@lob/lob-typescript-sdk'. <package> implicitly has an 'any' type.
  There are types at 'f/node_modules/@lob/lob-typescript-sdk/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@lob/lob-typescript-sdk' library may need to update its package.json or typings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `package.json` to make `exports.default` an object that includes `import` and `types` so TypeScript declarations are resolved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22586ae057f737a360c87be1b0f53cccb57b7e35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->