### PR TITLE
ci: draft a GitHub Release from the release workflow instead of publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,21 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+# This workflow does not publish to npm. It drafts a GitHub Release, and
+# npm_publish.yml does the publish when that draft is published.
+#
+# The draft is deliberate. GitHub does not start workflow runs for events raised
+# by GITHUB_TOKEN, so a release created and published here would never fire
+# npm_publish.yml's `release: published` trigger, and nothing would reach npm.
+# Publishing the draft yourself raises the event under your own token, which
+# does trigger it.
+permissions:
+  contents: write
 
 jobs:
-  publish:
+  draft-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,9 +27,41 @@ jobs:
       - run: npm install -g npm@11.5.1
       - run: npm ci
       - run: npm test
-      - uses: JS-DevTools/npm-publish@v3
+
+      - name: Draft a release for the version in package.json
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.NPM_TOKEN }}
-          tag: latest
-          access: public
-          check-version: true
+          script: |
+            const fs = require('fs');
+            const { version } = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const tag = `v${version}`;
+
+            // Every push to main reaches this step, but most do not bump the
+            // version. Bail out when the version already has a release so
+            // unrelated merges do not pile up duplicate drafts.
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const existing = releases.find((release) => release.tag_name === tag);
+
+            if (existing) {
+              core.info(
+                `${tag} already has a release (draft: ${existing.draft}): ${existing.html_url}`
+              );
+              return;
+            }
+
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              target_commitish: context.sha,
+              name: tag,
+              draft: true,
+              generate_release_notes: true,
+            });
+
+            core.notice(
+              `Drafted ${tag}. Publish it to release ${version} to npm: ${release.html_url}`
+            );


### PR DESCRIPTION
## Description

The `Release` workflow has failed on every run since 2026-01-15 with `Input required and not supplied: token`. This stops it publishing, and hands the publish to `npm_publish.yml`, which already does it correctly.

Only one file changes, `.github/workflows/release.yml`. `npm_publish.yml` is deliberately untouched.

### Why it was failing

`release.yml` asks for `NPM_TOKEN`. That secret was deliberately deleted in November 2025, when `c424f4e` moved `npm_publish.yml` to npm OIDC trusted publishing. Only that second workflow was migrated, so `release.yml` kept requesting a secret that no longer exists.

The repo therefore has two publish workflows, one of them broken, and they race on the same push. On 2026-06-05 `release.yml` failed at 22:13:48 while `npm_publish.yml` succeeded at 22:15:07 on the same commit. The red X and the successful publish of 1.4.0 were the same event.

Worth stating plainly: PR #293 did not cause this. It changed `npm install` into `npm install -g npm@11.5.1` plus `npm ci` and left the token line alone. The workflow had been red for seven months before that PR existed.

### What this changes

`release.yml` stops publishing and instead drafts a GitHub Release for whatever version `package.json` carries. Publishing that draft fires `npm_publish.yml`, which performs the publish over OIDC.

I considered giving `release.yml` its own OIDC credentials instead, mirroring `lob/react-address-autocomplete`. I backed that out. npm allows only one trusted publisher per package, and this package's is bound to the filename `npm_publish.yml`, so that route needs an `@lob` npm org admin to repoint it, which would break the existing path at the same moment. This version needs no npm-side change at all.

**The draft is deliberate, so please do not "simplify" it to `draft: false`.** GitHub does not start workflow runs for events raised by `GITHUB_TOKEN`, so a release both created and published by this workflow would never trigger `npm_publish.yml` and nothing would reach npm. A human publishing the draft raises the event under their own token, which does trigger it. GitHub's docs confirm the `published` activity type fires for releases published from drafts. The reasoning is in a comment in the file.

### Release process after this merges

1. Merge the version bump to `main`.
2. `release.yml` runs the tests and leaves a draft Release with generated notes.
3. Review it and click **Publish release**.
4. `npm_publish.yml` publishes to npm with a provenance attestation.

This replaces knowledge that was never written down. Previously a release required knowing to create one by hand, and the failing `Release` run made it look as though publishing access was broken. That is what this ticket was filed about.

### Notes for review

- The job is renamed from `publish` to `draft-release`, since it no longer publishes. No `workflow_run` consumer references this workflow, and `required_status_checks.contexts` on `main` is empty, so this breaks no gate.
- `permissions: contents: write` is needed to create the release. Nothing else is granted.
- `check-version` is gone with the publish step. It was never a valid input on npm-publish v3 anyway, which the 2026-08-19 logs show as `##[warning]Unexpected input(s) 'check-version'`.
- Adds `workflow_dispatch` so the workflow can be run by hand without an empty commit.
- The version check skips drafting when the version already has a release, so merges that do not bump the version do not pile up duplicate drafts.
- `node-version: 20` and `actions/checkout@v4` are left alone to keep the diff readable. Node 20 is deprecated on runners and force-run on Node 24, which is worth a separate change.

## Story

[PLATREQ-755](https://lobsters.atlassian.net/browse/PLATREQ-755)

## Related PR's

None. This does not come from the generator.

## Verify

- [ ] Code runs without errors
- [ ] Tests pass with >=85% coverage

### How this was verified

The workflow only triggers on push to `main`, so **it cannot run on this PR** and there will be no green check for it here. What I checked locally:

- The YAML parses, via `js-yaml`. The job key resolves to `draft-release` and `permissions.contents` to `write`.
- The embedded `github-script` body passes `node --check`, wrapped the way `github-script` wraps it. A syntax error there would otherwise only appear at runtime.
- `git diff main -- .github/workflows/npm_publish.yml` is 0 lines.
- No `secrets.` or `NPM_TOKEN` reference remains in `release.yml`.
- `npm ci` and the full suite, 1689 passing, were already green on `main` in the 2026-08-19 run, and this PR does not touch package code.

First real execution happens on merge. Expect it to log a skip rather than draft anything, because `package.json` is at 1.4.1 and a release for `v1.4.1` already exists. The first genuine draft appears on the next version bump.

### Already published

Unrelated to this diff, 1.4.1 is now on npm. `npm_publish.yml` published it successfully via OIDC on 2026-08-31, carrying a provenance attestation that names `.github/workflows/npm_publish.yml` at `refs/tags/v1.4.1`. That is the proof that the OIDC path this PR routes through is working today, and that no `NPM_TOKEN` is needed anywhere in this public repository.


[PLATREQ-755]: https://lobsters.atlassian.net/browse/PLATREQ-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ